### PR TITLE
chore: moving config into .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .cache/
 public
+.env.development

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -6,8 +6,8 @@ module.exports = {
     {
       resolve: "gatsby-source-contentful",
       options: {
-        accessToken: "7YCve82w4bnviOseBC0LOc-KacEYUzXWuw-FiqqWqjc",
-        spaceId: "9ceawlpyvxuq",
+        accessToken: process.env.CONTENTFUL_ACCESS_TOKEN,
+        spaceId: process.env.SPACE_ID,
       },
     },
     "gatsby-plugin-emotion",


### PR DESCRIPTION
For some reason, `gatbsy-cli` likes to store tokens in visible configurations.